### PR TITLE
reduce container columns size in gazette layout

### DIFF
--- a/_includes/layouts/gazette.njk
+++ b/_includes/layouts/gazette.njk
@@ -6,7 +6,7 @@ layout: layouts/base.njk
 
 <!-- <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--top"> -->
 <div class="fr-grid-row fr-grid-row--gutters">
-  <div class="fr-col-12 fr-col-md-12">
+  <div class="fr-col-md-8">
     {%- if date %}
       <p><time class="fr-tag" datetime="{{ date | htmlDateString }}">Publiée le {{ date | readableDate }}</time></p>
     {% endif %}


### PR DESCRIPTION
ceci devrait améliorer la lisibilité de la gazette sur desktop

cf https://gouvfr.atlassian.net/wiki/spaces/DB/pages/223019527/Typographie+-+Typography

> Il est recommandé de veiller à limiter le nombre de caractère par ligne. Nous vous recommandons d’utiliser un conteneur de maximum 8 colonnes pour les contenus.

Je ne suis pas sûr de comprendre la deuxième recommendation : 

> Pour les tailles de typographies S et XS, il est recommandé d’utiliser un conteneur moins large : en effet des études montrent qu’entre 45 et 75 caractères la lecture est satisfaisante pour le desktop, 35 à 40 caractères pour le mobile.

en tout cas il me semble qu'il est superflu de préciser `fr-col-12` c'est le comportement par défaut